### PR TITLE
Include cstdint for uint8_t in mobilenet example

### DIFF
--- a/armnn-mobilenet-quant/inference_test_image.hpp
+++ b/armnn-mobilenet-quant/inference_test_image.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <vector>
+#include <cstdint>
 
 // Parameters used in normalizing images
 struct NormalizationParameters


### PR DESCRIPTION
I had to include the header to get it to compile correctly. 