### PR TITLE
Add support for int16 quantization in convert.py

### DIFF
--- a/tflu-kws-cortex-m/Training/README.md
+++ b/tflu-kws-cortex-m/Training/README.md
@@ -47,11 +47,11 @@ make quantization of the trained models super simple.
 
 To quantize your trained model (e.g. a DNN) run:
 ```
-python convert.py --model_architecture dnn --model_size_info 128 128 128 --checkpoint <checkpoint_path> [--inference_type int8]
+python convert.py --model_architecture dnn --model_size_info 128 128 128 --checkpoint <checkpoint_path> [--inference_type int8|int16]
 ```
 The parameters used here should match those used in the Training step.
 
-The inference_type parameter is *optional* and to be used if a fully quantized model with inputs and outputs of type int8 is needed. It defaults to fp32.
+The inference_type parameter is *optional* and to be used if a fully quantized model with inputs and outputs of type int8 or int16 is needed. It defaults to fp32.
 
 This step will produce a quantized TFLite file *dnn_quantized.tflite*.
 You can test the accuracy of this quantized model on the test set by running:

--- a/tflu-kws-cortex-m/Training/convert.py
+++ b/tflu-kws-cortex-m/Training/convert.py
@@ -1,4 +1,4 @@
-# Copyright © 2021 Arm Ltd. All rights reserved.
+# Copyright © 2021-2022 Arm Ltd. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -88,10 +88,15 @@ def post_training_quantize(keras_model, inference_type, rep_dataset):
     if inference_type=='int8':
         converter.inference_input_type = tf.int8
         converter.inference_output_type = tf.int8
+        supported_ops = tf.lite.OpsSet.TFLITE_BUILTINS_INT8
+    if inference_type=='int16':
+        converter.inference_input_type = tf.int16
+        converter.inference_output_type = tf.int16
+        supported_ops = tf.lite.OpsSet.EXPERIMENTAL_TFLITE_BUILTINS_ACTIVATIONS_INT16_WEIGHTS_INT8
 
     # Int8 post training quantization needs representative dataset.
     converter.representative_dataset = rep_dataset
-    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+    converter.target_spec.supported_ops = [supported_ops]
 
     tflite_model = converter.convert()
 
@@ -223,7 +228,7 @@ if __name__ == '__main__':
         '--inference_type',
         type=str,
         default='fp32',
-        help='If quantize is true, whether the model input and output is float32 or int8')
+        help='If quantize is true, whether the model input and output is float32, int8 or int16')
 
     FLAGS, _ = parser.parse_known_args()
     main()

--- a/tflu-kws-cortex-m/Training/test_tflite.py
+++ b/tflu-kws-cortex-m/Training/test_tflite.py
@@ -1,4 +1,4 @@
-# Copyright © 2021 Arm Ltd. All rights reserved.
+# Copyright © 2021-2022 Arm Ltd. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -60,6 +60,7 @@ def tflite_inference(input_data, tflite_path):
     Returns:
         Output from inference.
     """
+    supported_quant_dtypes = (np.int8, np.int16)
     interpreter = tf.lite.Interpreter(model_path=tflite_path)
     interpreter.allocate_tensors()
 
@@ -71,15 +72,15 @@ def tflite_inference(input_data, tflite_path):
 
     # Check if the input/output type is quantized,
     # set scale and zero-point accordingly
-    if input_dtype == np.int8:
+    if input_dtype in supported_quant_dtypes:
         input_scale, input_zero_point = input_details[0]["quantization"]
     else:
         input_scale, input_zero_point = 1, 0
 
     input_data = input_data / input_scale + input_zero_point
-    input_data = np.round(input_data) if input_dtype == np.int8 else input_data
+    input_data = np.round(input_data) if input_dtype in supported_quant_dtypes else input_data
 
-    if output_dtype == np.int8:
+    if output_dtype in supported_quant_dtypes:
         output_scale, output_zero_point = output_details[0]["quantization"]
     else:
         output_scale, output_zero_point = 1, 0


### PR DESCRIPTION
This patch adds a new possible int16 value for --inference_type as
a way to enable int16 post training quantization. It makes use of
post-training int16 quantization support in TFLite, documented at [1].

[1] https://www.tensorflow.org/lite/performance/post_training_integer_quant_16x8

Co-authored-by: Leandro Nunes <Leandro.Nunes@arm.com>
