### PR TITLE
MLECO-3574: Provision to publish cmsis-pack-examples

### DIFF
--- a/.github/workflows/cmsis-pack-examples-push.yml
+++ b/.github/workflows/cmsis-pack-examples-push.yml
@@ -1,0 +1,48 @@
+#  Copyright (c) 2022 Arm Limited. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Sync CMSIS-pack example project into Arm-Examples repo
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - cmsis-pack-examples/**
+
+
+jobs:
+  publish-cmsis-examples:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Fetch action
+      id: get-cmsis-pack-files
+      uses: Rishabh510/Path-lister-action@1.0
+      with:
+        path: "cmsis-pack-examples/"
+        type: ".yml"
+    - name: Pushes test file
+      uses: nkoppel/push-files-to-another-repository@v1.1.1
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      with:
+          source-files: 'cmsis-pack-examples/*'
+          destination-username: 'Arm-Examples'
+          destination-repository: 'mlek-corstone-300-examples'
+          destination-branch: 'main'
+          commit-email: 'github-actions@arm.com'

--- a/.github/workflows/cmsis-pack-examples-zip.yml
+++ b/.github/workflows/cmsis-pack-examples-zip.yml
@@ -1,0 +1,57 @@
+#  Copyright (c) 2022 Arm Limited. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Publish CMSIS-pack example project zip file
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - cmsis-pack-examples/**
+
+jobs:
+  zip-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: vimtor/action-zip@v1
+        with:
+          files: cmsis-pack-examples/
+          recursive: true
+          dest: cmsis-pack-examples.zip
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.run_id }}
+          release_name: Release ${{ github.run_id }}
+          body: |
+            CMSIS example packs release
+          prerelease: false
+          draft: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/cmsis-pack-examples.zip
+          asset_name: cmsis-pack-examples.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Adding github action to sync and publish cmsis-pack-examples projects.

Change-Id: Ib2e26620ef67d98f92a04aefdc4aed9e7aa33c83
Signed-off-by: Kshitij Sisodia <kshitij.sisodia@arm.com>