### PR TITLE
MLECO-3603, MLECO-3548: Minor improvements

### DIFF
--- a/cmsis-pack-examples/README.md
+++ b/cmsis-pack-examples/README.md
@@ -1,53 +1,79 @@
-- [ML examples](#ml-examples)
-  - [Trademarks](#trademarks)
-  - [Licenses](#licenses)
+# CMSIS-Pack based Machine Learning Examples
+
+- [Introduction](#introduction)
+- [Overview](#overview)
+  - [Object detection](#object-detection)
+  - [Keyword spotting](#keyword-spotting)
+- [Building the examples](#building-the-examples)
   - [Prerequisites](#prerequisites)
     - [Tools](#tools)
     - [Packs](#packs)
   - [Download Software Packs](#download-software-packs)
-  - [Generate Project](#generate-project)
-# ML examples
+  - [Generate and build the project](#generate-and-build-the-project)
+  - [Application output](#application-output)
+- [Trademarks](#trademarks)
+- [Licenses](#licenses)
 
-A collection of ML examples using the CMSIS pack from [ml-embedded-eval-kit](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/refs/heads/main). Currently, a couple of examples are supported:
+## Introduction
 
-- Object detection
-- Keyword spotting
+This repository has a collection of Machine Learning (ML) examples using the CMSIS-Pack from
+[ML Embedded Evaluation Kit](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/refs/heads/main).
+Currently, a couple of examples are supported:
 
-## Trademarks
+- Object detection - detects objects in the input image.
+- Keyword spotting - detects specific keywords in the input audio stream.
 
-- Arm® and Cortex® are registered trademarks of Arm® Limited (or its subsidiaries) in the US and/or elsewhere.
-- Arm® and Ethos™ are registered trademarks or trademarks of Arm® Limited (or its subsidiaries) in the US and/or
-  elsewhere.
-- Arm® and Corstone™ are registered trademarks or trademarks of Arm® Limited (or its subsidiaries) in the US and/or
-  elsewhere.
-- Arm®, Keil® and µVision® are registered trademarks of Arm Limited (or its subsidiaries) in the US and/or elsewhere.
-- TensorFlow™, the TensorFlow logo, and any related marks are trademarks of Google Inc.
+Use this import button to open the solution in Keil Studio Cloud: [![Open in Keil Studio](https://img.shields.io/badge/Keil%20Studio-Import-blue?logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyNS40LjEsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA0NyAxNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNDcgMTQ7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+DQoJLnN0MHtmaWxsOiNGRkZGRkY7fQ0KPC9zdHlsZT4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik00LjcsN2MwLDIuMiwxLjQsNC4xLDMuNSw0LjFjMS44LDAsMy42LTEuNCwzLjYtNC4xYzAtMi44LTEuNy00LjItMy42LTQuMkM2LjIsMi45LDQuNyw0LjcsNC43LDcgTTExLjYsMC41DQoJaDIuOXYxM2gtMi45di0xLjNjLTAuOSwxLjEtMi4zLDEuNy0zLjcsMS43QzQsMTMuOSwxLjgsMTAuNiwxLjgsN2MwLTQuMywyLjctNi45LDYuMS02LjljMS41LDAsMi44LDAuNywzLjcsMS45VjAuNXoiLz4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0xOCwwLjVIMjF2MS4yYzAuMy0wLjQsMC43LTAuOCwxLjItMS4xYzAuNS0wLjMsMS4yLTAuNCwxLjctMC40YzAuOCwwLDEuNiwwLjIsMi4zLDAuNmwtMS4yLDIuOA0KCWMtMC40LTAuMy0xLTAuNC0xLjUtMC40Yy0wLjctMC4xLTEuMywwLjItMS44LDAuN0MyMSw0LjYsMjEsNS45LDIxLDYuOHY2LjdIMThWMC41eiIvPg0KPHBhdGggY2xhc3M9InN0MCIgZD0iTTI4LjIsMC41aDIuOXYxLjJjMC43LTAuOSwxLjktMS42LDMuMS0xLjZjMS4zLDAsMi42LDAuNywzLjIsMS45YzAuOS0xLjIsMi4yLTEuOSwzLjctMS45DQoJQzQyLjcsMCw0NCwwLjksNDQuNywyLjJjMC4yLDAuNCwwLjcsMS40LDAuNywzLjN2OC4xaC0yLjlWNi4zYzAtMS41LTAuMi0yLjEtMC4yLTIuM2MtMC4yLTAuNy0wLjktMS4yLTEuNy0xLjENCgljLTAuNywwLTEuMywwLjMtMS43LDAuOWMtMC41LDAuOC0wLjYsMS45LTAuNiwyLjl2Ni43aC0yLjlWNi4zYzAtMS41LTAuMi0yLjEtMC4yLTIuM2MtMC4yLTAuNy0wLjktMS4yLTEuNy0xLjENCgljLTAuNywwLTEuMywwLjMtMS43LDAuOWMtMC41LDAuOC0wLjYsMS45LTAuNiwyLjl2Ni43aC0yLjlMMjguMiwwLjV6Ii8+DQo8L3N2Zz4NCg==&logoWidth=47)](https://studio.keil.arm.com/?import=https://github.com/Arm-Examples/mlek-corstone-300-examples.git)
 
-## Licenses
+## Overview
 
-The application samples are provided under the Apache 2.0 license, see [License](./LICENSE).
+The examples presented in this repository showcase how to build and deploy end-to-end Machine
+Learning applications using existing code from various CMSIS-packs. These examples are built
+using Google's [TensorFlow Lite Micro framework](https://www.tensorflow.org/lite/microcontrollers)
+and Arm's [ML Embedded Evaluation Kit](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/refs/heads/main/Readme.md)
+API's. The embedded evaluation kit API pack has ready-to-use machine learning API's for several
+use cases covering typical `voice`, `vibration` and `vision` applications.
 
-Application input data sample files (audio or image files) and the neural network model files have
-been converted into C/C++ type arrays and are distributed under Apache 2.0 license. The models have
-been processed by the [Vela compiler](https://pypi.org/project/ethos-u-vela/) and then converted
-into C/C++ arrays to be baked into the example applications.
+Although the target platform here is Arm® Corstone™-300, the examples can be easily ported to new
+targets, potentially using physical (or virtual) peripherals for live data being fed into the
+neural network model. Corstone™-300 platform gives us the choice of executing the ML workload on
+Arm® Cortex®-M55 CPU or running it more efficiently on Arm® Ethos™-U55 NPU. The examples are set
+up to use the NPU by default with unsupported operators falling back on the CPU.
 
-| Example | Licence | Provenance |
-|---------------|---------|---------|
-| Keyword Spotting | Apache 2.0 | [micronet_medium](https://github.com/ARM-software/ML-zoo/raw/9f506fe52b39df545f0e6c5ff9223f671bc5ae00/models/keyword_spotting/micronet_medium/tflite_int8/) |
-| Object Detection | Apache 2.0 | [object_detection](https://github.com/emza-vs/ModelZoo/blob/v1.0/object_detection/) |
+### Object detection
 
-## Prerequisites
+This example uses a neural network model that specialises in detecting human faces in images.
+The input size for these images is 192x192 (monochrome) and the smallest face that can be
+detected is of size 20x20. The output of the application will be co-ordinates for rectangular
+bounding boxes for each detection.
+
+### Keyword spotting
+
+This example can detect up to twelve keywords in the input audio stream. The audio file used
+contains the keyword "down" being spoken.
+
+More details about the input for this example can be found [here](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/refs/heads/main/docs/use_cases/kws.md#preprocessing-and-feature-extraction).
+
+## Building the examples
+
+We recommend using [Keil Studio Cloud](https://studio.keil.arm.com/?import=https://github.com/Arm-Examples/mlek-corstone-300-examples.git) for building these examples.
+This is by far the easiest way to get started. However, it is possible to build these projects locally too and the following sections cover the requirements for such a
+set up.
+
+### Prerequisites
 
 For developing on a local host machine, we recommend a Linux based system as we test
 the flow of the instructions in that environment, but a Windows based machine should
 also work.
-### Tools
 
-The following tools are required if building on a local machine (and not using the project via Keil Studio Cloud):
+#### Tools
+
+The following tools are required if building on a local machine (and not using the project via
+Keil Studio Cloud):
 
 - [CMSIS-Toolbox 1.0.0](https://github.com/Open-CMSIS-Pack/devtools/releases) or higher.
-- Arm Compiler 6.18 (part of Keil MDK or Arm Development Studio, evaluation version sufficient for compilation).
+- Arm Compiler 6.18 (part of Keil MDK or Arm Development Studio, evaluation version sufficient
+  for compilation).
 - Arm Virtual Hardware for Corstone-300 v11.18.1 or a local installation of Fixed Virtual Platform
 
 > **NOTE**: For Linux, we recommend using the script installer as this sets up the
@@ -69,14 +95,16 @@ The following tools are required if building on a local machine (and not using t
 > $ source /home/user/cmsis-toolbox-linux64/etc/setup
 > ```
 
-### Packs
+#### Packs
 
-Access to the Internet to download the required packs are listed in the file
-[`mlek.csolution.yml`](./mlek.csolution.yml).
+CMSIS-Pack defines a standardized way to deliver software components, device parameters and board
+support information and code. A list of available CMSIS-Packs can be found
+[here](https://developer.arm.com/tools-and-software/embedded/cmsis/cmsis-packs).
 
-## Download Software Packs
+### Download Software Packs
 
-The `csolution.yml` file lists the software packs used in all projects. These can be downloaded using the following command:
+The [mlek.csolution.yml](./mlek.csolution.yml) file lists the software packs used in all projects. These can be
+downloaded using the following command:
 
 ```
 > csolution list packs -s mlek.csolution.yml -m > packlist.txt
@@ -90,7 +118,7 @@ The `csolution.yml` file lists the software packs used in all projects. These ca
 > $ source /home/user/cmsis-toolbox-linux64/etc/setup
 > ```
 
-## Generate Project
+### Generate and build the project
 
 1. Use the `csolution` command to create `.cprj` project files:
    ```
@@ -119,22 +147,69 @@ The `csolution.yml` file lists the software packs used in all projects. These ca
 > 1. During the build process required packs may be downloaded.
 > 2. The generator specified depends on CMake and the host platform OS.
 
-## Execute Project
+### Execute project
 
-The project is configured for execution on Arm Virtual Hardware which removes the requirement for a physical hardware board.
+The project is configured for execution on Arm Virtual Hardware which removes the requirement for
+a physical hardware board.
 
 - When using a Fixed Virtual Platform installed locally:
   ```
   > <path_to_installed_FVP> -a ./out/kws/AVH-U55/Debug/kws.Debug+AVH-U55.axf -C ethosu.num_macs=256
   ```
-  > **NOTE**: The FVP defaults to running 128 MAC configuration for Arm Ethos-U55 NPU.
+  > **NOTE**: The FVP defaults to running 128 MAC configuration for Arm® Ethos™-U55 NPU.
   > However, our default neural network model for the NPU is for 256 MAC configuration.
 
-- [Keil Studio Cloud](https://studio.keil.arm.com/) integrates also the Arm Virtual Hardware VHT_Corstone_SSE-300_Ethos-U55 model. The steps to use the example are:
-  - Start [Keil Studio Cloud](https://studio.keil.arm.com/) and login to the system using your account.
-  - Drag and drop this directory (cmsis-pack-examples) into the project pane.
-  - Select the *Active Project* from the drop down - it should show all projects referenced in the `csolution` file.
+- [Keil Studio Cloud](https://studio.keil.arm.com/) integrates also the Arm Virtual Hardware
+  VHT_Corstone_SSE-300_Ethos-U55 model. The steps to use the example are:
+  - Start [Keil Studio Cloud](https://studio.keil.arm.com/) and login to the system using your
+    account.
+  - Drag and drop this directory (cmsis-pack-examples) into the project pane, or use the import
+    button provided above, under [ML-examples](#ml-examples).
+  - Select the *Active Project* from the drop-down - it should show all projects referenced in
+    the `csolution` file.
   - Select *Target hardware* from the drop-down: **SSE-300 MPS3**
-  - Click **Run project** which executes the project build step and then starts running on Arm Virtual Hardware.
+  - Click **Run project** which executes the project build step and then starts running on Arm
+    Virtual Hardware.
 
 > **Note:** Arm Virtual Hardware models are also available on AWS Marketplace.
+
+### Application output
+
+Once the project can be built successfully, the execution on target hardware will show output of
+the application in `Output` window in Keil Studio Cloud. Currently, this includes the following:
+  - Arm® Ethos™-U55 NPU version information
+  - Information about model's memory allocation
+  - Running inference on specified input
+  - Output of inference
+  - Simulation information such as simulated time, user time, system time, etc
+
+The output is different for the two example applications:
+  - object detection application will detect two objects on the sample input image and will
+    present the detected bounding boxes for objects in the image.
+  - keyword spotting application will detect a keyword in the sample audio file and will present
+    the highest confidence score and the associated keyword label. Threshold, applied for a label
+    to be deemed valid, is also shown
+
+## Trademarks
+
+- Arm® and Cortex® are registered trademarks of Arm® Limited (or its subsidiaries) in the US and/or elsewhere.
+- Arm® and Ethos™ are registered trademarks or trademarks of Arm® Limited (or its subsidiaries) in the US and/or
+  elsewhere.
+- Arm® and Corstone™ are registered trademarks or trademarks of Arm® Limited (or its subsidiaries) in the US and/or
+  elsewhere.
+- Arm®, Keil® and µVision® are registered trademarks of Arm Limited (or its subsidiaries) in the US and/or elsewhere.
+- TensorFlow™, the TensorFlow logo, and any related marks are trademarks of Google Inc.
+
+## Licenses
+
+The application samples are provided under the Apache 2.0 license, see [License](./LICENSE).
+
+Application input data sample files (audio or image files) and the neural network model files have
+been converted into C/C++ type arrays and are distributed under Apache 2.0 license. The models have
+been processed by the [Vela compiler](https://pypi.org/project/ethos-u-vela/) and then converted
+into C/C++ arrays to be baked into the example applications.
+
+| Example | Licence | Provenance |
+|---------------|---------|---------|
+| Keyword Spotting | Apache 2.0 | [micronet_medium](https://github.com/ARM-software/ML-zoo/raw/9f506fe52b39df545f0e6c5ff9223f671bc5ae00/models/keyword_spotting/micronet_medium/tflite_int8/) |
+| Object Detection | Apache 2.0 | [object_detection](https://github.com/emza-vs/ModelZoo/blob/v1.0/object_detection/) |

--- a/cmsis-pack-examples/kws/kws.cproject.yml
+++ b/cmsis-pack-examples/kws/kws.cproject.yml
@@ -33,13 +33,11 @@ project:
             - +AVH-U65
         - file: src/main.cpp
 
-  misc:
-    - Link:
-        - --scatter=./mps3-sse-300.sct
+    - group: Device Files
+      files:
+        - file: mps3-sse-300.sct
 
-  # Note: Should be changed to "define" later.
-  # "For a transition period defines: is also accepted. However this will be deprecated."
-  defines:
+  define:
     - "ACTIVATION_BUF_SZ=0x00100000"
 
   layers:

--- a/cmsis-pack-examples/mlek.csolution.yml
+++ b/cmsis-pack-examples/mlek.csolution.yml
@@ -45,18 +45,13 @@ solution:
     - pack: tensorflow::tensorflow-lite-micro@1.22.5-rc4
 
   build-types:                                # defines toolchain options for 'debug' and 'release'
-    # ---------------------------------------------------------------------------------------------
-    # Debug builds do not work with AVH deployment yet with debug flag as the size of the binary
-    # is limited to 10MB. The additional C-CPP flag can be uncommented once this file limit has
-    # been increased to support files sizes of up to 32MB.
-    # ---------------------------------------------------------------------------------------------
     - type: Debug
       compiler: AC6
       debug: on
       misc:
         - C*:
           - -O0
-          #- g
+          - -g
 
     - type: Release
       compiler: AC6
@@ -68,20 +63,14 @@ solution:
   target-types:
     - type: AVH-U55
       device: ARM::SSE-300-MPS3
-
-      # Note: Should be changed to "define" later.
-      # "For a transition period defines: is also accepted. However this will be deprecated."
-      defines:
+      define:
         - "ETHOSU55"
 
     # Currently Keil Studio doesn't allow to switch between targets. Uncomment when this is
     # fixed.
     # - type: AVH-U65
     #   device: ARM::SSE-300-MPS3
-
-    #   # Note: Should be changed to "define" later.
-    #   # "For a transition period defines: is also accepted. However this will be deprecated."
-    #   defines:
+    #   define:
     #     - "ETHOSU65"
 
   projects:

--- a/cmsis-pack-examples/object-detection/object-detection.cproject.yml
+++ b/cmsis-pack-examples/object-detection/object-detection.cproject.yml
@@ -31,13 +31,11 @@ project:
             - +AVH-U65
         - file: src/main.cpp
 
-  misc:
-    - Link:
-        - --scatter=./mps3-sse-300.sct
+    - group: Device Files
+      files:
+        - file: mps3-sse-300.sct
 
-  # Note: Should be changed to "define" later.
-  # "For a transition period defines: is also accepted. However this will be deprecated."
-  defines:
+  define:
     - "ACTIVATION_BUF_SZ=0x00082000"
 
   layers:


### PR DESCRIPTION
Changes in ReadMe:
 * some context about the examples
 * an import button for Keil Studio Clould

Changes in the solution and project yml files:
 * ensuring the linker script is passed correctly during the build
 * debug compiler flag is re-enabled

Change-Id: I51ae81c372c1afff5b8450c74c55eacb121cfbe5
Signed-off-by: Nina Drozd <nina.drozd@arm.com>