### PR TITLE
Update cmsis-pack-example to toolbox 1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ packlist.txt
 RTE/
 out/
 tmp/
+*.cbuild.yml
+*.cbuild-idx.yml

--- a/cmsis-pack-examples/.cdefault.yml
+++ b/cmsis-pack-examples/.cdefault.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/cdefault.schema.json
+
+default:
+  # Note that we need AC6@6.18 or higher to compile for Corstone-310 target.
+  compiler: AC6
+
+  misc:
+    - for-compiler: AC6
+      CPP:
+        - -std=c++14 -fno-exceptions -Wno-license-management -fno-rtti
+      C:
+        - -std=c99 -Wno-license-management
+      Link:
+        - --entry=Reset_Handler
+        - --verbose
+        - --callgraph_file='callgraph'
+        - --map
+        - --info=sizes,totals,unused,compression,inline,summarysizes
+        - --list='diagnostics.map'
+        - --diag_suppress=L6439W,L6314W,L9931W

--- a/cmsis-pack-examples/common/common.clayer.yml
+++ b/cmsis-pack-examples/common/common.clayer.yml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
 

--- a/cmsis-pack-examples/device/alif-ensemble/alif-ensemble-E7-device.clayer.yml
+++ b/cmsis-pack-examples/device/alif-ensemble/alif-ensemble-E7-device.clayer.yml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
   description: Alif Ensemble E7 ML islands' CPU device layer (High-Performance and High-Efficiency Arm Cortex-M55 CPUs).

--- a/cmsis-pack-examples/device/corstone/corstone-device.clayer.yml
+++ b/cmsis-pack-examples/device/corstone/corstone-device.clayer.yml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
 

--- a/cmsis-pack-examples/device/frdm-k64f/frdm-k64f-device.clayer.yml
+++ b/cmsis-pack-examples/device/frdm-k64f/frdm-k64f-device.clayer.yml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
 
@@ -30,10 +30,6 @@ layer:
         - file: src/BoardInit.cpp
         - file: include/uart_stdout.h
         - file: include/BoardInit.hpp
-
-  misc:
-    - ASM:
-      - -masm=gnu
 
   components:
     - component: NXP::Device:CMSIS:MK64F12_header

--- a/cmsis-pack-examples/device/stm32f746-discovery/stm32f746-discovery-device.clayer.yml
+++ b/cmsis-pack-examples/device/stm32f746-discovery/stm32f746-discovery-device.clayer.yml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
 
@@ -47,10 +47,6 @@ layer:
 
       files:
         - file: src/stm32f7xx/drivers/cmsis/device/startup_stm32f746xx.s
-          for-compiler: AC6
-          misc:
-            - ASM:
-              - -masm=armasm
         - file: src/stm32f7xx/drivers/cmsis/device/system_stm32f7xx.c
 
   components:

--- a/cmsis-pack-examples/kws/kws.cproject.yml
+++ b/cmsis-pack-examples/kws/kws.cproject.yml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/cproject.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/cproject.schema.json
 
 project:
 

--- a/cmsis-pack-examples/mlek.csolution.yml
+++ b/cmsis-pack-examples/mlek.csolution.yml
@@ -14,26 +14,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/csolution.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/csolution.schema.json
 
 solution:
-
-  # Note that we need AC6@6.18 or higher to compile for Corstone-310 target.
-  compiler: AC6
-
-  misc:
-    - CPP:
-      - -std=c++14 -fno-exceptions -Wno-license-management -fno-rtti
-    - C:
-      - -std=c99 -Wno-license-management
-    - Link:
-      - --entry=Reset_Handler
-      - --verbose
-      - --callgraph_file='callgraph'
-      - --map
-      - --info=sizes,totals,unused,compression,inline,summarysizes
-      - --list='diagnostics.map'
-      - --diag_suppress=L6439W,L6314W,L9931W
 
   packs:
     - pack: ARM::CMSIS@5.9.0
@@ -56,17 +39,12 @@ solution:
     - type: Debug
       compiler: AC6
       debug: on
-      misc:
-        - C*:
-          - -O0
-          - -g
+      optimize: none
 
     - type: Release
       compiler: AC6
       debug: off
-      misc:
-        - C*:
-          - -Ofast
+      optimize: speed
 
   target-types:
     - type: AVH-SSE-300-U55

--- a/cmsis-pack-examples/object-detection/object-detection.cproject.yml
+++ b/cmsis-pack-examples/object-detection/object-detection.cproject.yml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/cproject.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/cproject.schema.json
 
 project:
 


### PR DESCRIPTION
- Enhance .gitignore with new temp files
- Moved compiler misc flags into .cdefault.yml
- Use optimize attribute instead of misc flags