### PR TITLE
Update task definition for Csolution 0.28.0

### DIFF
--- a/cmsis-pack-examples/.vscode/tasks.json
+++ b/cmsis-pack-examples/.vscode/tasks.json
@@ -63,10 +63,17 @@
             }
         },
         {
+            "label": "CMSIS Build",
             "type": "cmsis-csolution.build",
-            "project": "${command:cmsis-csolution.getCprjPath}",
+            "solution": "${command:cmsis-csolution.getSolutionPath}",
+            "project": "${command:cmsis-csolution.getProjectPath}",
+            "buildType": "${command:cmsis-csolution.getBuildType}",
+            "targetType": "${command:cmsis-csolution.getTargetType}",
             "problemMatcher": [],
-            "label": "cmsis-csolution.build: Build"
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         },
         {
             "type": "embedded-debug.flash",


### PR DESCRIPTION
The latest release of the Csolution extension changes the required task properties for the cmsis-csolution.build task. This PR updates to new sensible defaults.