### PR TITLE
MLECO-3805: Unblocking Arm Ethos-U65 NPU builds

### DIFF
--- a/cmsis-pack-examples/.vscode/tasks.json
+++ b/cmsis-pack-examples/.vscode/tasks.json
@@ -63,18 +63,22 @@
             }
         },
         {
-            "type": "cmsis-csolution.build",
-            "project": "${command:cmsis-csolution.getCprjPath}",
-            "problemMatcher": [],
-            "label": "cmsis-csolution.build: Build"
-        },
-        {
             "type": "embedded-debug.flash",
             "serialNumber": "${command:device-manager.getSerialNumber}",
             "program": "${command:cmsis-csolution.getBinaryFile}",
             "cmsisPack": "${command:device-manager.getDevicePack}",
             "problemMatcher": [],
             "label": "embedded-debug.flash: Flash Device"
+        },
+        {
+            "type": "cmsis-csolution.build",
+            "solution": "${command:cmsis-csolution.getSolutionPath}",
+            "project": "${command:cmsis-csolution.getProjectPath}",
+            "buildType": "${command:cmsis-csolution.getBuildType}",
+            "targetType": "${command:cmsis-csolution.getTargetType}",
+            "rebuild": false,
+            "problemMatcher": [],
+            "label": "cmsis-csolution.build: Build"
         }
     ],
 

--- a/cmsis-pack-examples/README.md
+++ b/cmsis-pack-examples/README.md
@@ -36,8 +36,8 @@ Target platforms supported:
 
 | Name                | Type                | IP                                            | Examples |
 |---------------------|---------------------|-----------------------------------------------|----------|
-| Arm® Corstone™-300  | Virtual or physical | Arm® Cortex®-M55 CPU with Arm® Ethos™-U55 NPU | All      |
-| Arm® Corstone™-310  | Virtual or physical | Arm® Cortex®-M85 CPU with Arm® Ethos™-U55 NPU | All      |
+| Arm® Corstone™-300  | Virtual or physical | Arm® Cortex®-M55 CPU with Arm® Ethos™-U55 or Arm® Ethos™-U65 NPU | All      |
+| Arm® Corstone™-310  | Virtual or physical | Arm® Cortex®-M85 CPU with Arm® Ethos™-U55 or Arm® Ethos™-U65 NPU | All      |
 | Alif Ensemble E7    | Physical board      | Arm® Cortex®-M55 CPU with Arm® Ethos™-U55 NPU | All      |
 | STM32F746G-Discovery| Physical board      | Arm® Cortex®-M7 CPU                           | KWS      |
 | NXP FRDM-K64F       | Physical board      | Arm® Cortex®-M4 CPU                           | KWS      |
@@ -173,34 +173,50 @@ downloaded using the following command:
     warning csolution: specified device 'MK64FN1M0VLL12' and board mounted device 'MK64FN1M0xxx12' are different
     warning csolution: specified device 'MK64FN1M0VLL12' and board mounted device 'MK64FN1M0xxx12' are different
     /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-300-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-300-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-310-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-310-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+Alif-E7-M55-HP.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-300-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-300-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-310-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-310-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Release+Alif-E7-M55-HP.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-300-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-300-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-310-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-310-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+Alif-E7-M55-HE.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+FRDM-K64F.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+STM32F746-DISCO.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-300-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-300-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-310-U55.cprj - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-310-U65.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+Alif-E7-M55-HE.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+FRDM-K64F.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+STM32F746-DISCO.cprj - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-300-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-300-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-310-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+AVH-SSE-310-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Debug+Alif-E7-M55-HP.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-300-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-300-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-310-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/object-detection/object-detection.Release+AVH-SSE-310-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/object-detection/object-detection.Release+Alif-E7-M55-HP.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-300-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-300-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-310-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Debug+AVH-SSE-310-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+Alif-E7-M55-HE.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+FRDM-K64F.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Debug+STM32F746-DISCO.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-300-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-300-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-310-U55.cbuild.yml - info csolution: file generated successfully
+    /home/user/cmsis-pack-examples/kws/kws.Release+AVH-SSE-310-U65.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+Alif-E7-M55-HE.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+FRDM-K64F.cbuild.yml - info csolution: file generated successfully
     /home/user/cmsis-pack-examples/kws/kws.Release+STM32F746-DISCO.cbuild.yml - info csolution: file generated successfully
@@ -431,3 +447,10 @@ spot immediately. Please help us improve this section by reporting them via GitH
    test against. While we try to develop using the latest versions of the CMSIS toolbox, Keil
    Studio Cloud can be using older versions. If you find an issue, please report it via
    [GitHub](https://github.com/Arm-Examples/mlek-cmsis-pack-examples/issues).
+
+6. Issues running with Arm® Ethos™-U65 NPU on Keil Studio Cloud
+
+   Currently Keil Studio Cloud only supports running with the Arm® Ethos™-U55 on AVH
+   virtual targets.
+   You can build the project but will have to run it on your local machine on an
+   installation of the equivalent Fixed Virtual Platform containing Arm® Ethos™-U65 NPU.

--- a/cmsis-pack-examples/device/corstone/src/BoardInit.cpp
+++ b/cmsis-pack-examples/device/corstone/src/BoardInit.cpp
@@ -30,7 +30,8 @@ extern "C" {
 #include CMSIS_device_header /* Gives us IRQ num, base addresses. */
 
 #if defined(ETHOSU_ARCH)
-#include "ethosu_driver.h" /* Arm Ethos-U driver header */
+#include "ethosu_driver.h" /* Arm Ethos-U NPU driver header */
+#include "ethosu_mem_config.h" /* Arm Ethos-U NPU memory config */
 
 #if defined(ETHOS_U_CACHE_BUF_SZ) && (ETHOS_U_CACHE_BUF_SZ > 0)
 static uint8_t cache_arena[ETHOS_U_CACHE_BUF_SZ] CACHE_BUF_ATTRIBUTE;
@@ -87,6 +88,8 @@ static int arm_ethosu_npu_init(void)
 
     /* Initialise Ethos-U device */
     const void* ethosu_base_address = (void*)(ETHOS_U55_APB_BASE_S);
+
+    debug("Cache arena: 0x%p\n", get_cache_arena());
 
     if (0 != (err = ethosu_init(&ethosu_drv,         /* Ethos-U driver device pointer */
                                 ethosu_base_address, /* Ethos-U NPU's base address. */

--- a/cmsis-pack-examples/kws/kws.cproject.yml
+++ b/cmsis-pack-examples/kws/kws.cproject.yml
@@ -82,7 +82,7 @@ project:
         - file: linker/alif-e7-m55-he.sct
           for-type: +Alif-E7-M55-HE
 
-  defines:
+  define:
     - ACTIVATION_BUF_SZ=131072
 
   layers:

--- a/cmsis-pack-examples/kws/src/main_wav.cpp
+++ b/cmsis-pack-examples/kws/src/main_wav.cpp
@@ -130,6 +130,8 @@ int main()
                                                       preProcess.m_audioDataWindowSize,
                                                       preProcess.m_audioDataStride);
 
+    debug("Using audio data from %s\n", get_filename(0));
+
     while (audioDataSlider.HasNext()) {
         const int16_t* inferenceWindow = audioDataSlider.Next();
 

--- a/cmsis-pack-examples/mlek.csolution.yml
+++ b/cmsis-pack-examples/mlek.csolution.yml
@@ -51,12 +51,12 @@ solution:
   target-types:
     - type: AVH-SSE-300-U55
       device: ARM::SSE-300-MPS3
-      defines:
+      define:
         - ETHOSU55
 
     - type: AVH-SSE-310-U55
       device: ARM::SSE-310-MPS3
-      defines:
+      define:
         - ETHOSU55
 
     - type: FRDM-K64F
@@ -69,27 +69,27 @@ solution:
 
     - type: Alif-E7-M55-HP
       device: AE722F80F55D5TE:M55_HP
-      defines:
+      define:
         - ETHOSU55
         - USART_DRV_NUM=2
 
     - type: Alif-E7-M55-HE
       device: AE722F80F55D5TE:M55_HE
-      defines:
+      define:
         - ETHOSU55
         - USART_DRV_NUM=4
 
-    # Currently Keil Studio doesn't allow switching between different NPU configurations.
-    # Uncomment when this is fixed.
-    # - type: AVH-SSE-300-U65
-    #   device: ARM::SSE-300-MPS3
-    #   defines:
-    #     - "ETHOSU65"
-    #
-    # - type: AVH-SSE-310-U65
-    #   device: ARM::SSE-310-MPS3
-    #   define:
-    #     - "ETHOSU65"
+    # NOTE: Currently Keil Studio Cloud doesn't allow switching between different NPU configurations.
+    #       Applicatons produced by this build will only work if the FVP is run manually.
+    - type: AVH-SSE-300-U65
+      device: ARM::SSE-300-MPS3
+      define:
+        - ETHOSU65
+
+    - type: AVH-SSE-310-U65
+      device: ARM::SSE-310-MPS3
+      define:
+        - ETHOSU65
 
   output-dirs:
     rtedir: ./$Project$/RTE

--- a/cmsis-pack-examples/object-detection/object-detection.cproject.yml
+++ b/cmsis-pack-examples/object-detection/object-detection.cproject.yml
@@ -36,7 +36,9 @@ project:
         - file: src/main_static.cpp
           for-type:
             - +AVH-SSE-300-U55
+            - +AVH-SSE-300-U65
             - +AVH-SSE-310-U55
+            - +AVH-SSE-310-U65
         - file: src/main_live.cpp
           for-type:
             - +Alif-E7-M55-HP
@@ -55,7 +57,7 @@ project:
           for-type: +Alif-E7-M55-HP
 
 
-  defines:
+  define:
     - "ACTIVATION_BUF_SZ=532480"
 
   layers:


### PR DESCRIPTION
On behalf of @kshitij-sisodia-arm 

---

Uncommenting new targets for Arm Corstone-300 and Corstone-310 based on Ethos-U65 NPU. These can't be executed from Keil Studio Cloud directly as there is no provision. The user can run them manually though.

Change-Id: I6bdcb78d840640eb0a22647b239a5961611806df
