### PR TITLE
Update audiogen app.

### DIFF
--- a/kleidiai-examples/audiogen/README.md
+++ b/kleidiai-examples/audiogen/README.md
@@ -28,15 +28,18 @@ The Stable Audio Open Small Model is made of three submodules: Conditioners (Tex
 
 ## Setup
 
-### Create a workspace directory
-Create a separate directory for managing the dependencies and repositories. Export the WORKSPACE variable to point to this directory, which you will use in the following steps:
+### Step 1
+Clone this repository in your terminal, then navigate to `kleidiai-examples/audiogen/` directory.
+
+### Step 2
+Create a workspace directory for managing the dependencies and repositories. Export the WORKSPACE variable to point to this directory, which you will use in the following steps:
 ```bash
 mkdir my-workspace
 export WORKSPACE=$PWD/my-workspace
 ```
 
-### Download the Stable Audio Open Small Model
-Stable Audio Open Small is an open-source model optimized for generating short audio samples, sound effects, and production elements using text prompts.
+### Step 3
+Download the Stable Audio Open Small Model. The model is open-source and optimized for generating short audio samples, sound effects, and production elements using text prompts.
 
 Login to HuggingFace and navigate to the model landing page: [https://huggingface.co/stabilityai/stable-audio-open-small/tree/main](https://huggingface.co/stabilityai/stable-audio-open-small/tree/main)
 

--- a/kleidiai-examples/audiogen/app/CMakeLists.txt
+++ b/kleidiai-examples/audiogen/app/CMakeLists.txt
@@ -5,72 +5,116 @@
 #
 
 cmake_minimum_required(VERSION 3.16)
+
 project(audiogen_runner)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+include(ExternalProject)
+
+message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+message(STATUS "CMAKE_HOST_SYSTEM_NAME: ${CMAKE_HOST_SYSTEM_NAME}")
+
+set(CMAKE_CXX_STANDARD 17)
+
+if(CMAKE_TOOLCHAIN_FILE)
+  list(APPEND TOOLCHAIN_CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
 endif()
 
-if(NOT ROOT_PATH)
-  set(ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/..)
+if(ANDROID_ABI)
+  list(APPEND TOOLCHAIN_CMAKE_ARGS -DANDROID_ABI=${ANDROID_ABI})
 endif()
 
-set(srcs audiogen.cpp)
+if(NOT TF_SRC_PATH)
+  include(FetchContent)
 
-# TFLite
-if(NOT TF_LIB_PATH)
-  message( FATAL_ERROR "TenserFlow library path is required, Flag TF_LIB_PATH must be set" )
+  FetchContent_Declare( 
+    tensorflow_src
+    GIT_REPOSITORY https://github.com/tensorflow/tensorflow.git
+    GIT_TAG 84dd28bbc29d75e6a6d917eb2998e4e8ea90ec56
+  )
+
+  FetchContent_MakeAvailable(tensorflow_src)
+
+  set(TENSORFLOW_SOURCE_DIR ${tensorflow_src_SOURCE_DIR})
+
+else()
+  set(TENSORFLOW_SOURCE_DIR ${TF_SRC_PATH})
 endif()
 
-if(NOT TF_INCLUDE_PATH)
-  message( FATAL_ERROR "TenserFlow include path is required, Flag TF_INCLUDE_PATH must be set" )
-endif()
+set(FLATBUFFERS_SOURCE_DIR ${TENSORFLOW_SOURCE_DIR}/tensorflow/lite/tools/cmake/native_tools/flatbuffers)
+set(FLATBUFFERS_BIN_DIR ${CMAKE_BINARY_DIR}/flatbuffers-host-bin)
+set(SENTENCEPIECE_SOURCE_DIR ${CMAKE_BINARY_DIR}/sentencepiece)
 
-# Flatbuffer
-if(NOT FLATBUFFER_INCLUDE_PATH)
-  message( FATAL_ERROR "Flatbuffer include path is required, Flag FLATBUFFER_INCLUDE_PATH must be set" )
-endif()
+# Step 1: Build flatc ---
+ExternalProject_Add(
+  flatc_build
+  PREFIX flatc
+  DOWNLOAD_COMMAND ""
+  SOURCE_DIR ${FLATBUFFERS_SOURCE_DIR}
+  BINARY_DIR ${FLATBUFFERS_BIN_DIR}
+  INSTALL_COMMAND ""
+)
 
-include(FetchContent)
-
-FetchContent_Declare(
+# Step 2: Build SentencePiece ---
+ExternalProject_Add(
   sentencepiece_src
   GIT_REPOSITORY https://github.com/google/sentencepiece.git
   GIT_TAG        v0.2.0
+  SOURCE_DIR ${SENTENCEPIECE_SOURCE_DIR}
+  CMAKE_ARGS
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    ${TOOLCHAIN_CMAKE_ARGS}
+  INSTALL_COMMAND ""
 )
 
-FetchContent_Populate(sentencepiece_src)
-add_subdirectory(${sentencepiece_src_SOURCE_DIR} ${sentencepiece_src_BINARY_DIR})
+#Get the path to the sentencepiece lib
+ExternalProject_Get_Property(sentencepiece_src BINARY_DIR)
+set(SENTENCEPIECE_LIB ${BINARY_DIR}/src/libsentencepiece.a)
 
-list(APPEND common_link_directories
-  ${TF_LIB_PATH}/)
-
-list(APPEND common_include_directories
-  ${ROOT_PATH}/runner
-  ${TF_INCLUDE_PATH}
-  ${FLATBUFFER_INCLUDE_PATH} )
-
-list(APPEND audiogen_runner_deps tensorflowlite)
+## Step 4: Build the audiogen app ---
+# Define source
+set(SRCS audiogen.cpp)
 
 add_executable(audiogen ${srcs})
 
-target_include_directories(audiogen PUBLIC
-  ${common_include_directories}
-  ${sentencepiece_SOURCE_DIR}/src)
+set(XNNPACK_ENABLE_ARM_SME2 OFF CACHE BOOL "" FORCE)
+set(TFLITE_HOST_TOOLS_DIR "${FLATBUFFERS_BIN_DIR}/_deps/flatbuffers-build" CACHE PATH "Host tools directory")
 
-target_link_directories(audiogen PUBLIC ${common_link_directories})
+# Because flatc is not available at configure time,
+# this workaround places a placeholder (an empty file called flatc) at the expected install location.
+file(WRITE ${FLATBUFFERS_BIN_DIR}/_deps/flatbuffers-build/flatc "")
 
-add_dependencies(audiogen sentencepiece)
-
-# It is required to avoid the linking with libsentencepiece.so
-list(APPEND audiogen_runner_deps ${sentencepiece_src_BINARY_DIR}/src/libsentencepiece.a)
-
-if(ANDROID)
-  list(APPEND audiogen_runner_deps log)
-endif()
-
-target_link_libraries(audiogen
-  ${audiogen_runner_deps}
+# LiteRT CMake configure stage
+add_subdirectory(
+  "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
+  "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite"
+  EXCLUDE_FROM_ALL
 )
 
-target_compile_options(audiogen PUBLIC)
+# Delete the placeholder flatc file after the LiteRT CMake configuration stage is complete.
+file(REMOVE ${FLATBUFFERS_BIN_DIR}/_deps/flatbuffers-build/flatc "")
+
+add_dependencies(tensorflow-lite flatc_build)
+
+target_compile_definitions(tensorflow-lite PRIVATE
+  TF_MAJOR_VERSION=0
+  TF_MINOR_VERSION=0
+  TF_PATCH_VERSION=0
+  TF_VERSION_SUFFIX=""
+)
+
+# Include headers
+target_include_directories(audiogen PRIVATE
+  ${TENSORFLOW_SOURCE_DIR}/tensorflow/lite
+  ${SENTENCEPIECE_SOURCE_DIR}/src
+)
+
+# Link with dependencies
+target_link_libraries(audiogen
+  tensorflow-lite
+  ${SENTENCEPIECE_LIB}
+)
+
+# Ensure dependency build order
+add_dependencies(audiogen flatc_build sentencepiece_src)
+
+

--- a/kleidiai-examples/audiogen/app/README.md
+++ b/kleidiai-examples/audiogen/app/README.md
@@ -8,13 +8,14 @@
 
 ## Dependencies
 - A host laptop/PC with a Linux®-based operating system (tested on Ubuntu® 20.04.4 LTS with x86_64) or with macOS®.
-- The Android™ NDK r25, which can be downloaded from [here](https://developer.android.com/ndk/downloads).
+- The Android™ NDK r27c, which can be downloaded from [here](https://developer.android.com/ndk/downloads).
 - CMake version: 3.16.0 or above, which can be downloaded from [here](https://cmake.org/download/)
-- The three models (T5, DiT, and AutoEncoder) that make up the Stable Audio Open Small model converted into LiteRT-compatible formats. Ensure you have followed the instructions provided in the `scripts/` folder’s [README.md](../scripts/README.md) file.
+- The three modules of Stable Audio Open Small model (T5, DiT, and AutoEncoder) converted into LiteRT-compatible formats.
+- You can follow the instructions provided in the `scripts/` folder’s [README.md](../scripts/README.md) file to generate the models.
 
 ## Goal
 
-This guide will show you how to build the <strong>LiteRT</strong> runtime along with the <strong>audio generation (audiogen)</strong> app contained in the single <strong>audiogen.cpp</strong> file. Instructions in this guide are provided for running the audiogen app either on an  Android™ device or on a reasonably modern platform with macOS®.
+This guide will show you how to build the <strong>audio generation (audiogen)</strong> app contained in the single <strong>audiogen.cpp</strong> file. Instructions in this guide are provided for running the audiogen app either on an  Android™ device or on a reasonably modern platform with macOS®.
 
 ## Building the Audio Generation App
 
@@ -26,135 +27,35 @@ To build the audiogen application, follow one the following sections depending o
 ### Build the audiogen app on Linux® (HOST) or macOS® (HOST) for Android™ (TARGET)
 
 #### Step 1
-In the `app/` folder, we recommend you set up a new virtual environment with Python 3.12 or later, for example, with <strong>virtualenv</strong>:
-
-```bash
-virtualenv -p python3.12 env3_12
-
-# Activate virtual environment
-source env3_12/bin/activate
-```
-
-#### Step 2
-Next, set the `LITERT_MODELS_PATH` environment variable to the path where your Stable Audio Open Small models exported to LiteRT are located:
+Navigate to the `audiogen/app/` folder. Set the `LITERT_MODELS_PATH` environment variable to the path where your Stable Audio Open Small models exported to LiteRT are located:
 
 ```bash
 export LITERT_MODELS_PATH=<path_to_your_litert_models>
 ```
 
+#### Step 2
+If you haven't installed the Android™ NDK r27c yet, download and extract the Android™ NDK r27c in the `app` directory:
+
+```bash
+# On Linux®
+wget https://dl.google.com/android/repository/android-ndk-r27c-linux.zip
+unzip android-ndk-r27c-linux
+
+# On macOS®
+curl https://dl.google.com/android/repository/android-ndk-r27c-darwin.zip -o android-ndk-r27c-darwin.zip
+unzip android-ndk-r27c-darwin
+```
+
+Set the `NDK_PATH` environment variable to the path where you extracted the Android™ NDK r27c:
+
+```bash
+export NDK_PATH=$(pwd)/android-ndk-r27c
+```
+> If you extracted the Android™ NDK to a different directory, be sure to update `NDK_PATH` accordingly.
+
 #### Step 3
-Download and install Bazel 7.4.1
-```bash
-# On Linux®
-wget https://github.com/bazelbuild/bazel/releases/download/6.1.1/bazel-7.4.1-installer-linux-x86_64.sh
-sudo bash bazel-7.4.1-installer-linux-x86_64.sh
 
-# On macOS®
-export BAZEL_VERSION=7.4.1
-curl -fLO "https://github.com/bazelbuild/bazel/releases/download/{$BAZEL_VERSION}/bazel-{$BAZEL_VERSION}-installer-darwin-arm64.sh"
-```
-
-#### Step 4
-Clone the TensorFlow project:
-
-```bash
-git clone https://github.com/tensorflow/tensorflow.git tensorflow_src
-```
-
-#### Step 5
-Enter the `tensorflow_src` directory, and checkout the `84dd28bbc29d75e6a6d917eb2998e4e8ea90ec56` commit:
-
-```bash
-cd tensorflow_src
-git checkout 84dd28bbc29d75e6a6d917eb2998e4e8ea90ec56
-```
-
-In the `tensorflow_src` directory, set the `TF_SRC_PATH` environment variable to its current path:
-
-```bash
-export TF_SRC_PATH=$(pwd)
-```
-
-#### Step 6
-Build flatbuffer:
-
-```bash
-mkdir flatc-native-build && cd flatc-native-build
-cmake ../tensorflow/lite/tools/cmake/native_tools/flatbuffers
-cmake --build .
-cd ..
-```
-
-#### Step 7
-Download and extract the Android™ NDK r25b.
-
-```bash
-# On Linux®
-wget https://dl.google.com/android/repository/android-ndk-r25b-linux.zip
-unzip android-ndk-r25b-linux
-
-# On macOS®
-wget https://dl.google.com/android/repository/android-ndk-r25b-darwin.zip
-unzip android-ndk-r25b-darwin
-mv android-ndk-r25b-darwin ~/Library/Android/android-ndk-r25b
-```
-
-#### Step 8
-Set the `NDK_PATH` environment variable to the path where you extracted the Android™ NDK r25b:
-
-```bash
-export NDK_PATH=<path_to_android_ndk_r25>
-```
-
-Make sure the path points to the root directory of the extracted NDK package (e.g., on Linux® "/home/user/Android/Sdk/ndk/25.2.9519653" or on macOS® "/Library/Android/android-ndk-r25b")
-
-#### Step 9
-In the `tensorflow_src` directory, configure the Bazel build:
-
-```bash
-./configure
-```
-
-After running the `configure` script, you'll be prompted with a series of questions to set up the Bazel build. When asked for the Android™ NDK location, ensure it matches the path specified in the `NDK_PATH` environment variable.
-
-To ensure reproducibility, we provide the following:
-
-```bash
-Please specify the location of python. [Default is ../app/.venv/bin/python3]:
-Please input the desired Python library path to use. Default is [/../app/.venv/lib/python3.10/site-packages]
-Do you wish to build TensorFlow with ROCm support? [y/N]: n
-Do you wish to build TensorFlow with CUDA support? [y/N]: n
-Do you want to use Clang to build TensorFlow? [Y/n]: n
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -Wno-sign-compare]:
-Would you like to interactively configure ./WORKSPACE for Android builds? [y/N]: y
-Please specify the home path of the Android NDK to use. [Default is /Users/../library/Android/Sdk/ndk-bundle]: ../Library/Android/android-ndk-r25b
-Please specify the (min) Android NDK API level to use. [Available levels: [16, 17, 18, 19, 21, 22, 23, 24, 26, 27, 28, 29, 30, 31, 32, 33]] [Default is 21]: 30
-Please specify the home path of the Android SDK to use. [Default is ../Library/Android/sdk]:
-Please specify the Android SDK API level to use. [Available levels: ['35']] [Default is 35]:
-Please specify an Android build tools version to use. [Available versions: ['35.0.0', '35.0.1', '36.0.0']] [Default is 36.0.0]:
-Do you wish to build TensorFlow with iOS support? [y/N]: n
-
-Configuration finished
-```
-#### Step 10
-Build the LiteRT dynamic library with the following command:
-
-```bash
-bazel build -c opt --config android_arm64 //tensorflow/lite:libtensorflowlite.so \
-    --define tflite_with_xnnpack=true \
-    --define xnn_enable_arm_i8mm=true \
-    --define tflite_with_xnnpack_qs8=true \
-    --define tflite_with_xnnpack_qu8=true
-```
-
-#### Step 11
-Build the audiogen application. To do so, from the `tensorflow_src`, go back to the `app` directory:
-
-```bash
-cd ../
-```
-
-Inside the `app` directory, create the `build` folder and navigate into it:
+Build the audiogen application. Inside the `app` directory, create the `build` folder and navigate into it:
 
 ```bash
 mkdir build && cd build
@@ -163,20 +64,14 @@ mkdir build && cd build
 Next, run CMake using the following command:
 
 ```bash
-cmake -DCMAKE_TOOLCHAIN_FILE=$NDK_PATH/build/cmake/android.toolchain.cmake \
-      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-      -DANDROID_ABI=arm64-v8a \
-      -DTF_INCLUDE_PATH=$TF_SRC_PATH \
-      -DTF_LIB_PATH=$TF_SRC_PATH/bazel-bin/tensorflow/lite \
-      -DFLATBUFFER_INCLUDE_PATH=$TF_SRC_PATH/flatc-native-build/flatbuffers/include \
-    ..
+cmake -DCMAKE_TOOLCHAIN_FILE=$NDK_PATH/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a ..
 ```
 
 Then, build the application:
 ```bash
 make -j
 ```
-#### Step 12
+#### Step 4
 At this point, you are ready to push the binaries to your Android™ device and run the audiogen application. To do so, use the `adb` tool to push all necessary files into `/data/local/tmp/app`
 
 ```bash
@@ -185,7 +80,6 @@ adb push audiogen /data/local/tmp/app
 adb push $LITERT_MODELS_PATH/dit_model.tflite /data/local/tmp/app
 adb push $LITERT_MODELS_PATH/autoencoder_model.tflite /data/local/tmp/app
 adb push $LITERT_MODELS_PATH/conditioners_float32.tflite /data/local/tmp/app
-adb push ${TF_SRC_PATH}/bazel-bin/tensorflow/lite/libtensorflowlite.so /data/local/tmp/app
 ```
 
 Since the tokenizer used in the audiogen application is based on <strong>SentencePiece</strong>, you’ll need to download the `spiece.model` file from:
@@ -193,7 +87,12 @@ https://huggingface.co/google-t5/t5-base/tree/main
 and transfer it to your device.
 
 ```bash
+# On Linux®
 wget https://huggingface.co/google-t5/t5-base/resolve/main/spiece.model
+adb push spiece.model /data/local/tmp/app
+
+# On macOS®
+curl https://huggingface.co/google-t5/t5-base/resolve/main/spiece.model -o spiece.model.zip
 adb push spiece.model /data/local/tmp/app
 ```
 
@@ -215,9 +114,10 @@ From there, you can then run the `audiogen` application, which requires just thr
 - **Model Path**: The directory containing your LiteRT models and `spiece.model` files
 - **Prompt**: A text description of the desired audio (e.g., *warm arpeggios on house beats 120BPM with drums effect*)
 - **CPU Threads**: The number of CPU threads to use (e.g., `4`)
+- **Seed**: Specifies the seed value for the random initializer. Changing the seed will produce different audio outputs
 
 ```bash
-LD_LIBRARY_PATH=. ./audiogen . "warm arpeggios on house beats 120BPM with drums effect" 4
+./audiogen . "warm arpeggios on house beats 120BPM with drums effect" 4
 ```
 
 If everything runs successfully, the generated audio will be saved in `.wav` format (`output.wav`) in the same directory as the `audiogen` binary. At this point, you can then retrieve it using the `adb` tool from a different Terminal and play it on your laptop or PC.
@@ -229,102 +129,14 @@ adb pull data/local/tmp/output.wav
 ### Build the audiogen app on macOS® (HOST) for macOS® (TARGET)
 
 #### Step 1
-In the `app/` folder, we recommend you set up a new virtual environment with Python 3.12 or later, for example, with <strong>virtualenv</strong>:
-
-```bash
-virtualenv -p python3.12 env3_12
-
-# Activate virtual environment
-source env3_12/bin/activate
-```
-
-#### Step 2
-Next, set the `LITERT_MODELS_PATH` environment variable to the path where your Stable Audio Open Small models exported to LiteRT are located:
+Navigate to the `audiogen/app/` folder. Set the `LITERT_MODELS_PATH` environment variable to the path where your Stable Audio Open Small models exported to LiteRT are located:
 
 ```bash
 export LITERT_MODELS_PATH=<path_to_your_litert_models>
 ```
 
-#### Step 3
-Download and install Bazel 7.4.1
-```bash
-export BAZEL_VERSION=7.4.1
-curl -fLO "https://github.com/bazelbuild/bazel/releases/download/{$BAZEL_VERSION}/bazel-{$BAZEL_VERSION}-installer-darwin-arm64.sh"
-```
-
-#### Step 4
-Clone the TensorFlow project:
-
-```bash
-git clone https://github.com/tensorflow/tensorflow.git tensorflow_src
-```
-
-#### Step 5
-Enter the `tensorflow_src` directory, and checkout the `84dd28bbc29d75e6a6d917eb2998e4e8ea90ec56` commit:
-
-```bash
-cd tensorflow_src
-git checkout 84dd28bbc29d75e6a6d917eb2998e4e8ea90ec56
-```
-
-In the `tensorflow_src` directory, set the `TF_SRC_PATH` environment variable to its current path:
-
-```bash
-export TF_SRC_PATH=$(pwd)
-```
-
-#### Step 6
-Build flatbuffer:
-
-```bash
-mkdir flatc-native-build && cd flatc-native-build
-cmake ../tensorflow/lite/tools/cmake/native_tools/flatbuffers
-cmake --build .
-cd ..
-```
-
-#### Step 7
-In the `tensorflow_src` directory, configure the Bazel build:
-
-```bash
-./configure
-```
-
-After running the `configure` script, you'll be prompted with a series of questions to set up the Bazel build.
-
-To ensure reproducibility, we provide the following:
-
-```bash
-Please specify the location of python. [Default is ../app/.venv/bin/python3]:
-Please input the desired Python library path to use. Default is [/../app/.venv/lib/python3.10/site-packages]
-Do you wish to build TensorFlow with ROCm support? [y/N]: n
-Do you wish to build TensorFlow with CUDA support? [y/N]: n
-Do you want to use Clang to build TensorFlow? [Y/n]: n
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -Wno-sign-compare]:
-Would you like to interactively configure ./WORKSPACE for Android builds? [y/N]: n
-Do you wish to build TensorFlow with iOS support? [y/N]: n
-
-Configuration finished
-```
-#### Step 8
-Build the LiteRT dynamic library with the following command:
-
-```bash
-bazel build -c opt --config macos //tensorflow/lite:libtensorflowlite.so \
-    --define tflite_with_xnnpack=true \
-    --define xnn_enable_arm_i8mm=true \
-    --define tflite_with_xnnpack_qs8=true \
-    --define tflite_with_xnnpack_qu8=true
-```
-
-#### Step 9
-Build the audiogen application. To do so, from the `tensorflow_src`, go back to the `app` directory:
-
-```bash
-cd ../
-```
-
-Inside the `app` directory, create the `build` folder and navigate into it:
+#### Step 2
+Build the audiogen application. Inside the `app` directory, create the `build` folder and navigate into it:
 
 ```bash
 mkdir build && cd build
@@ -333,11 +145,7 @@ mkdir build && cd build
 Next, run CMake using the following command:
 
 ```bash
-cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-      -DTF_INCLUDE_PATH=$TF_SRC_PATH \
-      -DTF_LIB_PATH=$TF_SRC_PATH/bazel-bin/tensorflow/lite \
-      -DFLATBUFFER_INCLUDE_PATH=$TF_SRC_PATH/flatc-native-build/flatbuffers/include \
-    ..
+cmake ..
 ```
 
 Then, build the application:
@@ -345,31 +153,25 @@ Then, build the application:
 make -j
 ```
 
-#### Step 10
+#### Step 3
 Since the tokenizer used in the audiogen application is based on <strong>SentencePiece</strong>, you’ll need to download the `spiece.model` file from: https://huggingface.co/google-t5/t5-base/tree/main
 and add it to your `$LITERT_MODELS_PATH`.
 
 ```bash
-cp ~/Downloads/spiece.model $LITERT_MODELS_PATH/
+curl https://huggingface.co/google-t5/t5-base/resolve/main/spiece.model -o $LITERT_MODELS_PATH/spiece.model
 ```
 
-### Step 11
-Copy the share LiteRT dynamic library to the `$LITERT_MODELS_PATH`.
-```bash
-cp $TF_SRC_PATH/bazel-bin/tensorflow/lite/libtensorflowlite.so $LITERT_MODELS_PATH/
-```
-
-#### Step 12
 At this point, you are ready to run the audiogen application.
 
 From there, you can then run the `audiogen` application, which requires just three input arguments:
 
 - **Model Path**: The directory containing your LiteRT models and `spiece.model` files
 - **Prompt**: A text description of the desired audio (e.g., *warm arpeggios on house beats 120BPM with drums effect*)
-- **CPU Threads**: The number of CPU threads to use (e.g., `4`)
+- **CPU Threads**: The number of CPU threads to use (e.g., `4`, `8`)
+- **Seed**: Specifies the seed value for the random initializer. Changing the seed will produce different audio outputs
 
 ```bash
-./build/audiogen $LITERT_MODELS_PATH "warm arpeggios on house beats 120BPM with drums effect" 4
+./audiogen $LITERT_MODELS_PATH "warm arpeggios on house beats 120BPM with drums effect" 4 99
 ```
 
 If everything runs successfully, the generated audio will be saved in `.wav` format (`output.wav`) in the `audiogen_app` folder. At this point, you can play it on your laptop or PC.

--- a/kleidiai-examples/audiogen/app/README.md
+++ b/kleidiai-examples/audiogen/app/README.md
@@ -15,7 +15,7 @@
 
 ## Goal
 
-This guide will show you how to build the <strong>audio generation (audiogen)</strong> app contained in the single <strong>audiogen.cpp</strong> file. Instructions in this guide are provided for running the audiogen app either on an  Android™ device or on a reasonably modern platform with macOS®.
+This guide will show you how to build the <strong>audio generation (audiogen)</strong> app contained in the single <strong>audiogen.cpp</strong> file. Instructions in this guide are provided for running the audiogen app either on an Android™ device or on a reasonably modern platform with macOS®.
 
 ## Building the Audio Generation App
 

--- a/kleidiai-examples/audiogen/scripts/README.md
+++ b/kleidiai-examples/audiogen/scripts/README.md
@@ -24,9 +24,8 @@ You will explore two different conversion routes, to convert the submodules to L
 ### Create a virtual environment and install dependencies.
 
 #### Step 1
-Create and activate a virtual environment (it is recommended to use Python 3.10 for compatibility with the specified packages):
+In the `/audiogen` folder, create and activate a virtual environment (it is recommended to use Python 3.10 for compatibility with the specified packages)
 ```bash
-cd $WORKSPACE
 python3.10 -m venv .venv
 source .venv/bin/activate
 ```
@@ -172,9 +171,8 @@ To convert the DiT and AutoEncoder submodules, run the [`export_dit_autoencoder.
 
 ```bash
 python3 ./scripts/export_dit_autoencoder.py --model_config "$WORKSPACE/model_config.json" --ckpt_path "$WORKSPACE/model.ckpt"
-# Optional Parameters --output_path "./"
 ```
 
 The three LiteRT format models will be required to run the audiogen application on Android™ device.
 
-You can now follow the instructions located in the `app/` directory to build the audio generation application.
+You can now follow the instructions located in the [`app/`](../app/README.md) directory to build the audio generation application.


### PR DESCRIPTION
 * Simplify the build process using CMake (remove the use of bazel and integrate the build of flatc into CMake).
 * Modify the instructions in the readme.md files to reflect CMake build changes.
 * Modify audiogen.cpp code to allow user to set the seed via the cmd.
 * Fix typo