### PR TITLE
Fix case-sensitive variable name in CMakeLists.txt

### DIFF
--- a/kleidiai-examples/audiogen/app/CMakeLists.txt
+++ b/kleidiai-examples/audiogen/app/CMakeLists.txt
@@ -74,7 +74,7 @@ set(SENTENCEPIECE_LIB ${BINARY_DIR}/src/libsentencepiece.a)
 # Define source
 set(SRCS audiogen.cpp)
 
-add_executable(audiogen ${srcs})
+add_executable(audiogen ${SRCS})
 
 set(XNNPACK_ENABLE_ARM_SME2 OFF CACHE BOOL "" FORCE)
 set(TFLITE_HOST_TOOLS_DIR "${FLATBUFFERS_BIN_DIR}/_deps/flatbuffers-build" CACHE PATH "Host tools directory")


### PR DESCRIPTION
## Summary
Fixed a case-sensitivity issue in `CMakeLists.txt` where `${srcs}` was used instead of `${SRCS}`.

## Problem
The build was failing with:
```
CMake Error at CMakeLists.txt:77 (add_executable):
  No SOURCES given to target: audiogen
```

## Solution
Changed `${srcs}` to `${SRCS}` on line 77 to match the variable defined on line 75.

## Testing
- [x] Project builds successfully
- [x] No CMake configuration errors

## Changes
- Line 77: `add_executable(audiogen ${srcs})` → `add_executable(audiogen ${SRCS})`