### PR TITLE
Specify Corstone-1000 version in documentation

### DIFF
--- a/ethos-u-corstone-1000/README.md
+++ b/ethos-u-corstone-1000/README.md
@@ -16,7 +16,8 @@ All builds require CMake 3.25 or newer.
 
 Before running these examples on the FVP, build the Corstone-1000 with
 Cortex-A320 FVP and full BSP by following the guidance at
-[corstone1000.docs.arm.com](https://corstone1000.docs.arm.com/).
+[corstone1000.docs.arm.com/en/corstone1000-2025.12](https://corstone1000.docs.arm.com/en/corstone1000-2025.12/).
+N.B. the `corstone1000-2025.12` tagged version of the project is currently required.
 
 For Corstone-1000 AArch64 builds, put the Bootlin AArch64 musl toolchain on
 `PATH`.

--- a/ethos-u-corstone-1000/docs/DEPLOYING.md
+++ b/ethos-u-corstone-1000/docs/DEPLOYING.md
@@ -17,8 +17,8 @@ You need:
 The model setup, project build, and MMC packaging steps do not require this
 Yocto Project workspace. The workspace is only needed when running the image.
 
-Create the workspace by following the latest Corstone-1000 build guide:
-https://corstone1000.docs.arm.com/en/latest/user-guide.html#build
+Create the workspace by following the Corstone-1000 build guide at tagged version `corstone1000-2025.12`:
+https://corstone1000.docs.arm.com/en/corstone1000-2025.12/user-guide.html#build
 
 The FVP helper defaults can be supplied with:
 
@@ -114,8 +114,8 @@ Boot, shell, FVP, secure-world, and secure-enclave output are kept in separate
 files under that `logs` directory. `Testing/FVP/<test>/combined.log` preserves
 all sections for deeper debugging.
 
-For a Yocto Project workspace, follow the latest Corstone-1000 build guide:
-https://corstone1000.docs.arm.com/en/latest/user-guide.html#build
+For a Yocto Project workspace, follow the Corstone-1000 build guide tagged at version `corstone1000-2025.12`:
+https://corstone1000.docs.arm.com/en/corstone1000-2025.12/user-guide.html#build
 
 Create and populate the project Python virtual environment before configuring
 or running FVP CTests:


### PR DESCRIPTION
* Update the Ethos-U Direct Drive examples documentation to specify the version of the Corstone-1000 build guide to use with the project

Change-Id: I9a9c5382bbc4a4a07fc7d5d2f0b2f40866c259f7